### PR TITLE
Add %open_notebook(as ipyida) + rewrite magic-variable namespace

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,16 +8,13 @@ import types
 import threading
 import signal
 import ctypes
-import dataclasses
 
 from typing import Optional
 from concurrent.futures import ThreadPoolExecutor
 
-import jupyter_client.session
 import qasync
 
 import binaryninja as bn
-import traitlets
 
 from PySide6.QtCore import QEvent, Qt
 from PySide6.QtWidgets import QApplication, QVBoxLayout
@@ -25,7 +22,6 @@ from binaryninjaui import GlobalAreaWidget, GlobalArea
 from binaryninja import PluginCommand
 from ipykernel.kernelapp import IPKernelApp
 from ipykernel.ipkernel import IPythonKernel, ZMQInteractiveShell
-from jupyter_client.connect import KernelConnectionInfo
 from IPython.core.interactiveshell import ExecutionResult
 
 # Hack required for bundled PySide6 to work with QtPy
@@ -38,7 +34,7 @@ sys.modules["PySide6.QtPrintSupport"].QPrintDialog = types.ModuleType("EmptyQPag
 os.environ["QT_API"] = "PySide6"
 
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
-from qtconsole.manager import QtKernelManager, QtKernelManagerMixin
+from qtconsole.manager import QtKernelManager
 from qtconsole.client import QtKernelClient
 from qtconsole.styles import default_dark_style_sheet, default_dark_syntax_style
 
@@ -46,7 +42,6 @@ from .user_ns import UserNamespaceProvider
 from .os_router import BinjaExceptionHookRouter
 from .magic_functions import NavMagic, PackagingMagics
 from .kernelspec import InstallKernelSpecTask
-from .kernelrun import read_env_connection_config, ConnectionConfig
 
 
 class ZMQThreadedShell(ZMQInteractiveShell):
@@ -68,20 +63,13 @@ class ZMQThreadedShell(ZMQInteractiveShell):
             return False
         return True
 
-    async def _update_ns_and_run(self, *args, cell_id, **kwargs):
-        assert cell_id is not None
-        session = cell_id['session']
-        ipybinja_client = cell_id['ipybinja_client']
-        remote_client_id = session if not ipybinja_client else None
-        self.user_ns.update_magic_snapshot(remote_client_id)
-        return await super().run_cell_async(*args, **kwargs, cell_id=cell_id['cellId'])
-
     async def run_cell_async(self, *args, **kwargs) -> ExecutionResult:
+        self.user_ns.update_magic_snapshot()
         loop = asyncio.get_running_loop()
         future = asyncio.ensure_future(loop.run_in_executor(
             self._executor,
             asyncio.run,
-            self._update_ns_and_run(*args, **kwargs)
+            super().run_cell_async(*args, **kwargs)
         ))
 
         # Raise KeyboardInterrupt on executor thread when we receive SIGINT
@@ -100,17 +88,6 @@ class ZMQThreadedShell(ZMQInteractiveShell):
 
 class ThreadedKernel(IPythonKernel):
     shell_class = ZMQThreadedShell
-
-    async def execute_request(self, stream, ident, parent):
-        # HACK: Extract information from message to pass to shell
-        # This information is used by shell to ID remote clients
-        metadata = parent.setdefault("metadata", {})
-        metadata['cellId'] = {
-            'cellId': metadata.get('cellId', None),
-            'session': parent.get('header', {}).get('session'),
-            'ipybinja_client': parent.get('header', {}).get('ipybinjaClient', False)
-        }
-        return await super().execute_request(stream, ident, parent)
 
 
 class IPythonKernelApp:
@@ -150,19 +127,6 @@ class IPythonKernelApp:
         logging.debug(f'configure_path modified PATH to {os.environ["PATH"]}')
 
     @classmethod
-    def apply_env_connection_config(cls, kernel: IPKernelApp) -> bool:
-        config = read_env_connection_config()
-        if config is None:
-            return False
-        kernel_config: KernelConnectionInfo = {}
-        for k, v in dataclasses.asdict(config).items():
-            if v is not None and k != 'file':
-                kernel_config[k] = v
-        kernel.connection_file = config.file or "kernel-%s.json" % os.getpid()
-        kernel.load_connection_info(kernel_config)
-        return True
-
-    @classmethod
     def _create_app(cls) -> IPKernelApp:
         cls._configure_venv()
         cls._configure_path()
@@ -177,7 +141,11 @@ class IPythonKernelApp:
             user_ns=UserNamespaceProvider(),
             exec_files=cls._get_exec_files()
         )
-        cls.apply_env_connection_config(app)
+        connection_file = cls._get_env_connection_file()
+        if connection_file is not None:
+            logging.warning(f'using IPyConsole connection file {connection_file} from '
+                            f'IPYTHON_BINJA_CONNECTION_FILE env variable')
+            app.connection_file = connection_file
         app.initialize()
         app.shell.set_completer_frame()
         app.shell.register_magics(NavMagic, PackagingMagics)
@@ -205,23 +173,6 @@ class IPythonKernelApp:
     @classmethod
     def _get_env_connection_file(cls) -> Optional[str]:
         return os.environ.get('IPYTHON_BINJA_CONNECTION_FILE', None)
-    
-    @property
-    def config(self) -> ConnectionConfig:
-        config = ConnectionConfig(
-            file=self.app.abs_connection_file,
-            ip=str(self.app.ip),
-            key=self.app.session.key.decode(),
-            transport=str(self.app.transport),
-            hb_port=self.app.hb_port,
-            iopub_port=self.app.iopub_port,
-            shell_port=self.app.shell_port,
-            stdin_port=self.app.stdin_port,
-            control_port=self.app.control_port,
-            signature_scheme=self.app.session.signature_scheme,
-            kernel_name=str(self.app.kernel_name),
-        )
-        return config
 
 
 class BinjaRichJupyterWidget(RichJupyterWidget):
@@ -242,27 +193,6 @@ class BinjaRichJupyterWidget(RichJupyterWidget):
         signal.raise_signal(signal.SIGINT)
 
 
-class CustomKernelClientSession(jupyter_client.session.Session):
-
-    def msg_header(self, *args, **kwargs):
-        header = super().msg_header(*args, **kwargs)
-        # Used by the kernel to determine if message is from embedded
-        # IPython console
-        header['ipybinjaClient'] = True
-        return header
-
-
-class CustomKernelClient(QtKernelClient):
-    session = traitlets.Instance(f'{__name__}.CustomKernelClientSession')
-
-
-class CustomKernelManager(QtKernelManager):
-    client_class = traitlets.DottedObjectName(f'{__name__}.CustomKernelClient')
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, session=CustomKernelClientSession())
-
-
 class IPythonWidget(GlobalAreaWidget):
     def __init__(self, name):
         super(IPythonWidget, self).__init__(name)
@@ -273,17 +203,9 @@ class IPythonWidget(GlobalAreaWidget):
         self._thread_id = threading.current_thread().native_id
 
     def _create_widget(self) -> RichJupyterWidget:
-        self.kernel_manager = CustomKernelManager()
-        config = self.kernel.config
-        self.kernel_manager.ip = config.ip
-        self.kernel_manager.stdin_port = config.stdin_port
-        self.kernel_manager.control_port = config.control_port
-        self.kernel_manager.hb_port = config.hb_port
-        self.kernel_manager.session.signature_scheme = config.signature_scheme
-        self.kernel_manager.session.key = config.key.encode()
-        self.kernel_manager.shell_port = config.shell_port
-        self.kernel_manager.transport = config.transport
-        self.kernel_manager.iopub_port = config.iopub_port
+        self.kernel_manager = QtKernelManager(connection_file=self.kernel.connection_file)
+        self.kernel_manager.load_connection_file()
+        self.kernel_manager.client_factory = QtKernelClient
         self.kernel_client = self.kernel_manager.client()
         self.kernel_client.start_channels()
         widget = BinjaRichJupyterWidget(

--- a/__init__.py
+++ b/__init__.py
@@ -12,224 +12,286 @@ import ctypes
 from typing import Optional
 from concurrent.futures import ThreadPoolExecutor
 
-import qasync
-
 import binaryninja as bn
-
-from PySide6.QtCore import QEvent, Qt
-from PySide6.QtWidgets import QApplication, QVBoxLayout
-from binaryninjaui import GlobalAreaWidget, GlobalArea
 from binaryninja import PluginCommand
-from ipykernel.kernelapp import IPKernelApp
-from ipykernel.ipkernel import IPythonKernel, ZMQInteractiveShell
-from IPython.core.interactiveshell import ExecutionResult
 
-# Hack required for bundled PySide6 to work with QtPy
-sys.modules["PySide6.QtOpenGL"] = types.ModuleType("EmptyQtOpenGL")
-sys.modules["PySide6.QtOpenGLWidgets"] = types.ModuleType("EmptyQtOpenGLWidgets")
-sys.modules["PySide6.QtOpenGLWidgets"].QOpenGLWidget = types.ModuleType("EmptyQOpenGLWidget")
-sys.modules["PySide6.QtPrintSupport"] = types.ModuleType("EmptyQtPrintSupport")
-sys.modules["PySide6.QtPrintSupport"].QPageSetupDialog = types.ModuleType("EmptyQPageSetupDialog")
-sys.modules["PySide6.QtPrintSupport"].QPrintDialog = types.ModuleType("EmptyQPageSetupDialog")
-os.environ["QT_API"] = "PySide6"
-
-from qtconsole.rich_jupyter_widget import RichJupyterWidget
-from qtconsole.manager import QtKernelManager
-from qtconsole.client import QtKernelClient
-from qtconsole.styles import default_dark_style_sheet, default_dark_syntax_style
-
-from .user_ns import UserNamespaceProvider
-from .os_router import BinjaExceptionHookRouter
-from .magic_functions import NavMagic, PackagingMagics
-from .kernelspec import InstallKernelSpecTask
-
-
-class ZMQThreadedShell(ZMQInteractiveShell):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._tid = None
-        self._executor = ThreadPoolExecutor(1, 'CustomShell', initializer=self._thread_initializer)
-        # Prevents kernel from crashing with attribute not found error when a magic command fails
-        self._last_traceback = None
-
-    def _thread_initializer(self):
-        self._tid = threading.current_thread().ident
-
-    def should_run_async(self, raw_cell: str, *, transformed_cell=None, preprocessing_exc_tuple=None):
-        if not self.autoawait:
-            return False
-        if preprocessing_exc_tuple is not None:
-            return False
-        return True
-
-    async def run_cell_async(self, *args, **kwargs) -> ExecutionResult:
-        self.user_ns.update_magic_snapshot()
-        loop = asyncio.get_running_loop()
-        future = asyncio.ensure_future(loop.run_in_executor(
-            self._executor,
-            asyncio.run,
-            super().run_cell_async(*args, **kwargs)
-        ))
-
-        # Raise KeyboardInterrupt on executor thread when we receive SIGINT
-        def sigint_handler(*_):
-            if ctypes.pythonapi.PyThreadState_SetAsyncExc(
-                    ctypes.c_long(self._tid), ctypes.py_object(KeyboardInterrupt)
-            ) != 1:
-                ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(self._tid), None)
-
-        handler_orig = signal.signal(signal.SIGINT, sigint_handler)
-        try:
-            return await future
-        finally:
-            signal.signal(signal.SIGINT, handler_orig)
-
-
-class ThreadedKernel(IPythonKernel):
-    shell_class = ZMQThreadedShell
-
-
-class IPythonKernelApp:
-
-    def __init__(self):
-        if IPKernelApp.initialized():
-            self.app = IPKernelApp.instance()
-        else:
-            self.app = IPythonKernelApp._create_app()
-        self.connection_file = self.app.abs_connection_file
-    
-    @classmethod
-    def _configure_venv(cls):
-        if 'VIRTUAL_ENV' in os.environ:
-            logging.debug(f'skipping configure_venv since VIRTUAL_ENV env var is set')
-            return
-        site_packages = bn.Settings().get_string('python.virtualenv', None)
-        if site_packages is None:
-            logging.debug(f'skipping configure_venv since python.virtualenv is None')
-            return
-        if sys.platform == "win32":
-            venv = os.path.abspath(os.path.join(site_packages, '..', '..'))
-        else:
-            venv = os.path.abspath(os.path.join(site_packages, '..', '..', '..'))
-        os.environ['VIRTUAL_ENV'] = venv
-        
-    @classmethod
-    def _configure_path(cls):
-        python_binary = bn.Settings().get_string('python.binaryOverride')
-        site_packages = bn.Settings().get_string('python.virtualenv')
-        if site_packages is None or python_binary is None:
-            logging.debug('skipping configure_path since python.virtualenv or '
-                          'python.binaryOverride is None')
-            return
-        binary_dir = os.path.dirname(python_binary)
-        os.environ['PATH'] = f'{binary_dir}{os.pathsep}{os.environ["PATH"]}'
-        logging.debug(f'configure_path modified PATH to {os.environ["PATH"]}')
-
-    @classmethod
-    def _create_app(cls) -> IPKernelApp:
-        cls._configure_venv()
-        cls._configure_path()
-        app = IPKernelApp.instance(
-            kernel_class=f'{__name__}.ThreadedKernel',
-            outstream_class=f'{__name__}.os_router.BinjaStdOutRouter',
-            displayhook_class=f'{__name__}.os_router.BinjaDisplayHookRouter',
-            # We provide our own logger here because the default one from
-            # traitlets adds a handler that expect stderr to be a regular
-            # file object
-            log=logging.getLogger("ipybinja_kernel"),
-            user_ns=UserNamespaceProvider(),
-            exec_files=cls._get_exec_files()
-        )
-        connection_file = cls._get_env_connection_file()
-        if connection_file is not None:
-            logging.warning(f'using IPyConsole connection file {connection_file} from '
-                            f'IPYTHON_BINJA_CONNECTION_FILE env variable')
-            app.connection_file = connection_file
-        app.initialize()
-        app.shell.set_completer_frame()
-        app.shell.register_magics(NavMagic, PackagingMagics)
-        app.kernel.start()
-        sys.excepthook = BinjaExceptionHookRouter(app.shell.excepthook)
-        return app
-
-    @classmethod
-    def _get_exec_files(cls) -> list[str]:
-        user_dir = bn.user_directory()
-        if user_dir is not None:
-            ipybinja = os.path.join(user_dir, 'ipybinja.py')
-            startup = os.path.join(user_dir, 'startup.py')
-            scripts = []
-            if os.path.exists(ipybinja):
-                scripts.append(ipybinja)
-            if os.path.exists(startup):
-                scripts.append(startup)
-            else:
-                logging.warning(f'startup.py not found in Binary Ninja user home dir {user_dir}')
-            return scripts
-        logging.warning(f'Failed to get Binary Ninja user directory')
-        return []
-
-    @classmethod
-    def _get_env_connection_file(cls) -> Optional[str]:
-        return os.environ.get('IPYTHON_BINJA_CONNECTION_FILE', None)
-
-
-class BinjaRichJupyterWidget(RichJupyterWidget):
-    
-    def eventFilter(self, obj, event):
-        # Workaround for handling cases when Ctrl-C event
-        # is not received on KeyPress
-        if event.type() == QEvent.KeyRelease and \
-            self._control_key_down(event.modifiers(), include_command=False) and \
-            event.key() == Qt.Key_C and \
-            self._executing:
-                self.interrupt_kernel()
-                return True
-        return super().eventFilter(obj, event)
-
-    # noinspection PyMethodMayBeStatic
-    def interrupt_kernel(self):
-        signal.raise_signal(signal.SIGINT)
-
-
-class IPythonWidget(GlobalAreaWidget):
-    def __init__(self, name):
-        super(IPythonWidget, self).__init__(name)
-        self.kernel = IPythonKernelApp()
-        self.layout = QVBoxLayout()
-        self.layout.addWidget(self._create_widget())
-        self.setLayout(self.layout)
-        self._thread_id = threading.current_thread().native_id
-
-    def _create_widget(self) -> RichJupyterWidget:
-        self.kernel_manager = QtKernelManager(connection_file=self.kernel.connection_file)
-        self.kernel_manager.load_connection_file()
-        self.kernel_manager.client_factory = QtKernelClient
-        self.kernel_client = self.kernel_manager.client()
-        self.kernel_client.start_channels()
-        widget = BinjaRichJupyterWidget(
-            self.layout.widget(),
-            style_sheet=default_dark_style_sheet,
-            syntax_style=default_dark_syntax_style
-        )
-        widget.kernel_manager = self.kernel_manager
-        widget.kernel_client = self.kernel_client
-        return widget
-
-
-if not isinstance(asyncio.get_event_loop(), qasync.QEventLoop):
-    qapp = QApplication.instance()
-    loop = qasync.QEventLoop(qapp, already_running=True)
-    asyncio.set_event_loop(loop)
-
-GlobalArea.addWidget(
-    lambda _: IPythonWidget('IPython Console')
-)
+# Bootstrap: register the requirements installer FIRST, before any
+# requirements.txt-provided module is imported. If those imports fail
+# below, the plugin still loads far enough for this command to be
+# usable from the command palette so the user can recover.
+from .install import InstallRequirementsTask
 
 PluginCommand.register(
-    'IPyBinja\\Install Jupyter Kernel',
-    'Install jupyter kernel configuration for Binary Ninja',
-    lambda _: InstallKernelSpecTask().start(),
-    lambda _: True
+    'IPyBinja\\Install Plugin Requirements',
+    "Install ipybinja's requirements.txt into Binary Ninja's site-packages",
+    lambda _: InstallRequirementsTask().start(),
+    lambda _: True,
 )
+
+
+try:
+    import qasync
+
+    from PySide6.QtCore import QEvent, Qt
+    from PySide6.QtWidgets import QApplication, QVBoxLayout
+    from binaryninjaui import GlobalAreaWidget, GlobalArea
+    from ipykernel.kernelapp import IPKernelApp
+    from ipykernel.ipkernel import IPythonKernel, ZMQInteractiveShell
+    from IPython.core.interactiveshell import ExecutionResult
+
+    # Hack required for bundled PySide6 to work with QtPy
+    sys.modules["PySide6.QtOpenGL"] = types.ModuleType("EmptyQtOpenGL")
+    sys.modules["PySide6.QtOpenGLWidgets"] = types.ModuleType("EmptyQtOpenGLWidgets")
+    sys.modules["PySide6.QtOpenGLWidgets"].QOpenGLWidget = types.ModuleType("EmptyQOpenGLWidget")
+    sys.modules["PySide6.QtPrintSupport"] = types.ModuleType("EmptyQtPrintSupport")
+    sys.modules["PySide6.QtPrintSupport"].QPageSetupDialog = types.ModuleType("EmptyQPageSetupDialog")
+    sys.modules["PySide6.QtPrintSupport"].QPrintDialog = types.ModuleType("EmptyQPageSetupDialog")
+    os.environ["QT_API"] = "PySide6"
+
+    from qtconsole.rich_jupyter_widget import RichJupyterWidget
+    from qtconsole.manager import QtKernelManager
+    from qtconsole.client import QtKernelClient
+    from qtconsole.styles import default_dark_style_sheet, default_dark_syntax_style
+
+    from .user_ns import UserNamespaceProvider
+    from .os_router import BinjaExceptionHookRouter
+    from .magic_functions import NavMagic, PackagingMagics, NotebookMagic
+    from .kernelspec import InstallKernelSpecTask
+
+
+    def _patch_debugpy_in_process_adapter():
+        # Binary Ninja's bundled python.exe ships with python<ver>._pth where
+        # `import site` is commented out, so subprocesses ignore PYTHONPATH
+        # and miss user site-packages. Default debugpy.listen() spawns
+        # `python -m debugpy.adapter` to broker DAP -- that subprocess can't
+        # import debugpy, never connects back, and endpoints_listener.accept()
+        # times out; the user sees the TimeoutError as a Binary Ninja dialog
+        # when they click Debug in JupyterLab/Notebook.
+        #
+        # Forcing in_process_debug_adapter=True keeps pydevd in-process and
+        # skips the subprocess. JupyterLab's debug UI still works: it talks
+        # to the kernel via Jupyter debug_request messages, not directly to
+        # debugpy.
+        #
+        # We replace the public entry point (debugpy.listen) rather than
+        # debugpy.server.api.listen -- the inner listen function body does
+        # `if listen.called` against its own module globals, so replacing
+        # api.listen would point that lookup at our wrapper (which has no
+        # `.called` attribute) and raise AttributeError.
+        try:
+            import debugpy as _debugpy
+        except Exception:
+            return
+        if getattr(_debugpy, "_ipybinja_in_process_patched", False):
+            return
+        _orig_public_listen = _debugpy.listen
+
+        def _patched_public_listen(*args, **kwargs):
+            kwargs["in_process_debug_adapter"] = True
+            return _orig_public_listen(*args, **kwargs)
+
+        _debugpy.listen = _patched_public_listen
+        _debugpy._ipybinja_in_process_patched = True
+
+    _patch_debugpy_in_process_adapter()
+
+
+    class ZMQThreadedShell(ZMQInteractiveShell):
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._tid = None
+            self._executor = ThreadPoolExecutor(1, 'CustomShell', initializer=self._thread_initializer)
+            # Prevents kernel from crashing with attribute not found error when a magic command fails
+            self._last_traceback = None
+
+        def _thread_initializer(self):
+            self._tid = threading.current_thread().ident
+
+        def should_run_async(self, raw_cell: str, *, transformed_cell=None, preprocessing_exc_tuple=None):
+            if not self.autoawait:
+                return False
+            if preprocessing_exc_tuple is not None:
+                return False
+            return True
+
+        async def run_cell_async(self, *args, **kwargs) -> ExecutionResult:
+            self.user_ns.update_magic_snapshot()
+            loop = asyncio.get_running_loop()
+            future = asyncio.ensure_future(loop.run_in_executor(
+                self._executor,
+                asyncio.run,
+                super().run_cell_async(*args, **kwargs)
+            ))
+
+            # Raise KeyboardInterrupt on executor thread when we receive SIGINT
+            def sigint_handler(*_):
+                if ctypes.pythonapi.PyThreadState_SetAsyncExc(
+                        ctypes.c_long(self._tid), ctypes.py_object(KeyboardInterrupt)
+                ) != 1:
+                    ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(self._tid), None)
+
+            handler_orig = signal.signal(signal.SIGINT, sigint_handler)
+            try:
+                return await future
+            finally:
+                signal.signal(signal.SIGINT, handler_orig)
+
+
+    class ThreadedKernel(IPythonKernel):
+        shell_class = ZMQThreadedShell
+
+
+    class IPythonKernelApp:
+
+        def __init__(self):
+            if IPKernelApp.initialized():
+                self.app = IPKernelApp.instance()
+            else:
+                self.app = IPythonKernelApp._create_app()
+            self.connection_file = self.app.abs_connection_file
+
+        @classmethod
+        def _configure_venv(cls):
+            if 'VIRTUAL_ENV' in os.environ:
+                logging.debug(f'skipping configure_venv since VIRTUAL_ENV env var is set')
+                return
+            site_packages = bn.Settings().get_string('python.virtualenv', None)
+            if site_packages is None:
+                logging.debug(f'skipping configure_venv since python.virtualenv is None')
+                return
+            if sys.platform == "win32":
+                venv = os.path.abspath(os.path.join(site_packages, '..', '..'))
+            else:
+                venv = os.path.abspath(os.path.join(site_packages, '..', '..', '..'))
+            os.environ['VIRTUAL_ENV'] = venv
+
+        @classmethod
+        def _configure_path(cls):
+            python_binary = bn.Settings().get_string('python.binaryOverride')
+            site_packages = bn.Settings().get_string('python.virtualenv')
+            if site_packages is None or python_binary is None:
+                logging.debug('skipping configure_path since python.virtualenv or '
+                              'python.binaryOverride is None')
+                return
+            binary_dir = os.path.dirname(python_binary)
+            os.environ['PATH'] = f'{binary_dir}{os.pathsep}{os.environ["PATH"]}'
+            logging.debug(f'configure_path modified PATH to {os.environ["PATH"]}')
+
+        @classmethod
+        def _create_app(cls) -> IPKernelApp:
+            cls._configure_venv()
+            cls._configure_path()
+            app = IPKernelApp.instance(
+                kernel_class=f'{__name__}.ThreadedKernel',
+                outstream_class=f'{__name__}.os_router.BinjaStdOutRouter',
+                displayhook_class=f'{__name__}.os_router.BinjaDisplayHookRouter',
+                # We provide our own logger here because the default one from
+                # traitlets adds a handler that expect stderr to be a regular
+                # file object
+                log=logging.getLogger("ipybinja_kernel"),
+                user_ns=UserNamespaceProvider(),
+                exec_files=cls._get_exec_files()
+            )
+            connection_file = cls._get_env_connection_file()
+            if connection_file is not None:
+                logging.warning(f'using IPyConsole connection file {connection_file} from '
+                                f'IPYTHON_BINJA_CONNECTION_FILE env variable')
+                app.connection_file = connection_file
+            app.initialize()
+            app.shell.set_completer_frame()
+            app.shell.register_magics(NavMagic, PackagingMagics)
+            app.shell.register_magics(NotebookMagic(
+                shell=app.shell, connection_file=app.abs_connection_file
+            ))
+            app.kernel.start()
+            sys.excepthook = BinjaExceptionHookRouter(app.shell.excepthook)
+            return app
+
+        @classmethod
+        def _get_exec_files(cls) -> list[str]:
+            user_dir = bn.user_directory()
+            if user_dir is not None:
+                ipybinja = os.path.join(user_dir, 'ipybinja.py')
+                startup = os.path.join(user_dir, 'startup.py')
+                scripts = []
+                if os.path.exists(ipybinja):
+                    scripts.append(ipybinja)
+                if os.path.exists(startup):
+                    scripts.append(startup)
+                else:
+                    logging.warning(f'startup.py not found in Binary Ninja user home dir {user_dir}')
+                return scripts
+            logging.warning(f'Failed to get Binary Ninja user directory')
+            return []
+
+        @classmethod
+        def _get_env_connection_file(cls) -> Optional[str]:
+            return os.environ.get('IPYTHON_BINJA_CONNECTION_FILE', None)
+
+
+    class BinjaRichJupyterWidget(RichJupyterWidget):
+
+        def eventFilter(self, obj, event):
+            # Workaround for handling cases when Ctrl-C event
+            # is not received on KeyPress
+            if event.type() == QEvent.KeyRelease and \
+                self._control_key_down(event.modifiers(), include_command=False) and \
+                event.key() == Qt.Key_C and \
+                self._executing:
+                    self.interrupt_kernel()
+                    return True
+            return super().eventFilter(obj, event)
+
+        # noinspection PyMethodMayBeStatic
+        def interrupt_kernel(self):
+            signal.raise_signal(signal.SIGINT)
+
+
+    class IPythonWidget(GlobalAreaWidget):
+        def __init__(self, name):
+            super(IPythonWidget, self).__init__(name)
+            self.kernel = IPythonKernelApp()
+            self.layout = QVBoxLayout()
+            self.layout.addWidget(self._create_widget())
+            self.setLayout(self.layout)
+            self._thread_id = threading.current_thread().native_id
+
+        def _create_widget(self) -> RichJupyterWidget:
+            self.kernel_manager = QtKernelManager(connection_file=self.kernel.connection_file)
+            self.kernel_manager.load_connection_file()
+            self.kernel_manager.client_factory = QtKernelClient
+            self.kernel_client = self.kernel_manager.client()
+            self.kernel_client.start_channels()
+            widget = BinjaRichJupyterWidget(
+                self.layout.widget(),
+                style_sheet=default_dark_style_sheet,
+                syntax_style=default_dark_syntax_style
+            )
+            widget.kernel_manager = self.kernel_manager
+            widget.kernel_client = self.kernel_client
+            return widget
+
+
+    if not isinstance(asyncio.get_event_loop(), qasync.QEventLoop):
+        qapp = QApplication.instance()
+        loop = qasync.QEventLoop(qapp, already_running=True)
+        asyncio.set_event_loop(loop)
+
+    GlobalArea.addWidget(
+        lambda _: IPythonWidget('IPython Console')
+    )
+
+    PluginCommand.register(
+        'IPyBinja\\Install Jupyter Kernel',
+        'Install jupyter kernel configuration for Binary Ninja',
+        lambda _: InstallKernelSpecTask().start(),
+        lambda _: True
+    )
+
+except ImportError as e:
+    bn.log_warn(
+        f"ipybinja: a required dependency is not installed ({e}). "
+        f"Open the command palette and run "
+        f"'IPyBinja\\Install Plugin Requirements', then restart Binary Ninja."
+    )

--- a/__init__.py
+++ b/__init__.py
@@ -204,6 +204,16 @@ try:
             app.shell.register_magics(NotebookMagic(
                 shell=app.shell, connection_file=app.abs_connection_file
             ))
+            # JupyterLab / Notebook 7 frontends open a `jupyter.widget.control`
+            # comm at session start to discover existing widgets. That target
+            # is normally registered by ipywidgets; without it ipykernel logs
+            # "No such comm target registered: jupyter.widget.control" plus a
+            # follow-up "No such comm: <uuid>" for the frontend's first
+            # comm_msg. We register a no-op handler so the comm opens
+            # silently and the follow-up msg is dropped without warning.
+            app.kernel.comm_manager.register_target(
+                'jupyter.widget.control', lambda comm, msg: None,
+            )
             app.kernel.start()
             sys.excepthook = BinjaExceptionHookRouter(app.shell.excepthook)
             return app

--- a/install.py
+++ b/install.py
@@ -1,0 +1,203 @@
+"""pip-install helpers and the "Install Plugin Requirements" background task.
+
+Binary Ninja's plugin manager auto-installs ``requirements.txt`` only for
+plugins installed via the plugin manager. For plugins dropped into
+``%APPDATA%/Binary Ninja/plugins/`` manually (git clone, symlink, ...) we
+need our own install path. The directory-resolution and pip-invocation
+logic here mirrors Binary Ninja's own ``ScriptingInstance._install_modules``
+(``scriptingprovider.py:1219``) so we land packages where the embedded
+interpreter actually imports from.
+"""
+
+import importlib
+import logging
+import os
+import pathlib
+import subprocess
+import sys
+
+import binaryninja as bn
+
+from .utils import detect_python_path
+
+
+def binja_site_packages_dir() -> str:
+    """Return the directory where pip must install for Binary Ninja's
+    embedded interpreter to find the package.
+
+    Mirrors the resolution in ``ScriptingInstance._install_modules``:
+      1) Honor ``python.virtualenv`` setting if it ends in ``site-packages``,
+         exists on disk, and we're not already inside an active venv.
+      2) Otherwise install to ``<user_dir>/python<major><minor>/site-packages``,
+         creating it if needed.
+    """
+    venv = bn.Settings().get_string("python.virtualenv")
+    in_virtual_env = "VIRTUAL_ENV" in os.environ
+    if (
+        venv
+        and venv.endswith("site-packages")
+        and pathlib.Path(venv).is_dir()
+        and not in_virtual_env
+    ):
+        return venv
+    user_dir = bn.user_directory()
+    if user_dir is None:
+        raise RuntimeError("Unable to find Binary Ninja user directory")
+    target = pathlib.Path(user_dir) / (
+        f"python{sys.version_info.major}{sys.version_info.minor}"
+    ) / "site-packages"
+    target.mkdir(parents=True, exist_ok=True)
+    return str(target)
+
+
+def binja_pythonpath_env(base_env=None) -> dict:
+    """Return an environment dict with Binary Ninja's user site-packages
+    prepended to PYTHONPATH.
+
+    Binary Ninja's GUI process adds ``<user_dir>/python<ver>/site-packages``
+    to ``sys.path`` at startup, but a standalone ``python.exe`` child
+    process does not inherit that. Subprocesses that need to import
+    packages we ``pip install``ed must be told via PYTHONPATH where to
+    find them.
+    """
+    env = dict(base_env if base_env is not None else os.environ)
+    try:
+        binja_site = binja_site_packages_dir()
+    except Exception:
+        return env
+    existing = env.get("PYTHONPATH", "")
+    parts = existing.split(os.pathsep) if existing else []
+    if binja_site not in parts:
+        env["PYTHONPATH"] = (
+            binja_site + (os.pathsep + existing if existing else "")
+        )
+    return env
+
+
+def _python_executable() -> str:
+    path = detect_python_path()
+    if path is None:
+        raise RuntimeError(
+            "Could not locate a Python interpreter. Configure "
+            "python.binaryOverride in Binary Ninja settings."
+        )
+    return path
+
+
+def _hidden_window_startupinfo():
+    if sys.platform != "win32":
+        return None
+    si = subprocess.STARTUPINFO()
+    si.dwFlags = subprocess.STARTF_USESHOWWINDOW
+    si.wShowWindow = subprocess.SW_HIDE
+    return si
+
+
+def _run_pip(target: str, install_args: list) -> bool:
+    """Run pip with the canonical Binary Ninja flags and stream combined
+    stdout/stderr to the logger (so users see errors even though the
+    embedded Python has no inherited console on Windows).
+
+    ``install_args`` is appended after ``install --upgrade --upgrade-strategy
+    only-if-needed --target <target>`` -- pass either bare package names or
+    ``["-r", "<requirements.txt>"]``.
+    """
+    python = _python_executable()
+    cmd = [
+        python, "-m", "pip", "--isolated", "--disable-pip-version-check",
+    ]
+    proxy = bn.Settings().get_string("network.httpsProxy")
+    if proxy:
+        cmd += ["--proxy", proxy]
+    cmd += [
+        "install", "--upgrade", "--upgrade-strategy", "only-if-needed",
+        "--target", target,
+    ]
+    cmd += install_args
+    logging.info(f"ipybinja: running {cmd}")
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1,
+            startupinfo=_hidden_window_startupinfo(),
+        )
+    except OSError as e:
+        print(f"-> Failed to launch pip: {e}")
+        return False
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        print(line, end="")
+    rc = proc.wait()
+    if rc != 0:
+        print(f"-> pip exited with code {rc}")
+        return False
+    importlib.invalidate_caches()
+    if target not in sys.path:
+        sys.path.insert(0, target)
+    return True
+
+
+def pip_install_packages(*packages: str) -> bool:
+    """Install one or more packages by name into Binary Ninja's site-packages.
+    Returns True on success.
+    """
+    if not packages:
+        return True
+    target = binja_site_packages_dir()
+    label = ", ".join(packages)
+    print(f"-> Installing {label} into {target}...")
+    return _run_pip(target, list(packages))
+
+
+def pip_install_requirements_file(req_path: str) -> bool:
+    """Install every entry in a requirements.txt-style file into Binary
+    Ninja's site-packages. Returns True on success.
+    """
+    if not os.path.exists(req_path):
+        print(f"-> requirements file not found: {req_path}")
+        return False
+    target = binja_site_packages_dir()
+    print(f"-> Installing requirements from {req_path} into {target}...")
+    return _run_pip(target, ["-r", req_path])
+
+
+def _plugin_requirements_path() -> str:
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "requirements.txt")
+
+
+class InstallRequirementsTask(bn.BackgroundTaskThread):
+    """One-click install of ipybinja's requirements.txt into the location
+    Binary Ninja's embedded interpreter actually reads from. Useful after
+    clearing site-packages, or for fresh manual (non-plugin-manager) installs.
+    """
+
+    _MSG_BOX_TITLE = "IPyBinja Install Plugin Requirements"
+
+    def __init__(self):
+        super().__init__("Installing IPyBinja plugin requirements", can_cancel=False)
+
+    def _show_message(self, msg: str, is_error: bool = False):
+        bn.interaction.show_message_box(
+            self._MSG_BOX_TITLE,
+            text=msg,
+            icon=bn.MessageBoxIcon.ErrorIcon if is_error else bn.MessageBoxIcon.InformationIcon,
+        )
+
+    def run(self):
+        req = _plugin_requirements_path()
+        try:
+            ok = pip_install_requirements_file(req)
+        except Exception as e:
+            self._show_message(f"Installation failed: {e}", is_error=True)
+            return
+        if ok:
+            self._show_message(
+                "Plugin requirements installed. You may need to restart "
+                "Binary Ninja before all packages take effect."
+            )
+        else:
+            self._show_message(
+                "pip reported errors. See the Log view for details.",
+                is_error=True,
+            )

--- a/magic_functions.py
+++ b/magic_functions.py
@@ -8,8 +8,9 @@ import binaryninja as bn
 import binaryninjaui as bnui
 
 from IPython.core.magic import Magics, magics_class, line_magic
-from .user_ns import BinjaMagicVarSnapshot
+from .user_ns import _BinjaMagicVariablesProvider
 from .utils import detect_python_path
+from .notebook import NotebookManager
 
 
 class _NavMagicError(Exception):
@@ -24,7 +25,7 @@ class NavMagic(Magics):
 
     @property
     def _binja_ns(self):
-        return BinjaMagicVarSnapshot(bnui.UIContext.activeContext())
+        return _BinjaMagicVariablesProvider(bnui.UIContext.activeContext())
 
     @classmethod
     def _parse_int(cls, arg: str, min_val: Optional[int] = None, max_val: Optional[int] = None) -> int:
@@ -110,7 +111,7 @@ class NavMagic(Magics):
 
 @magics_class
 class PackagingMagics(Magics):
-    
+
     @line_magic
     def pip(self, line):
         python = detect_python_path()
@@ -118,7 +119,7 @@ class PackagingMagics(Magics):
             print(f'Error: failed to detect path to python binary. '
                   f'Configure python.binaryOverride setting in Binary Ninja to fix this problem')
             return
-        
+
         if sys.platform == "win32":
             python = '"' + python + '"'
         else:
@@ -127,3 +128,26 @@ class PackagingMagics(Magics):
         self.shell.system(" ".join([python, "-m", "pip", line]))
 
         print("Note: you may need to restart the kernel to use updated packages.")
+
+
+@magics_class
+class NotebookMagic(Magics):
+
+    def __init__(self, shell=None, connection_file=None, **kwargs):
+        super().__init__(shell=shell, **kwargs)
+        self._manager = NotebookManager(connection_file)
+
+    @line_magic
+    def open_notebook(self, line):
+        """Launch (or reuse) a Jupyter Notebook connected to this Binary Ninja
+        IPython kernel and open it in the default browser.
+        """
+        try:
+            return self._manager.open_notebook(line)
+        except Exception as e:
+            logging.error(f'open_notebook failed: {e}')
+
+    @line_magic
+    def notebook_log(self, line):
+        """Print stdout from the Jupyter Notebook started by %open_notebook."""
+        self._manager.notebook_log(line)

--- a/notebook.py
+++ b/notebook.py
@@ -3,6 +3,7 @@
 # Launch a Jupyter Notebook from Binary Ninja and connect it to the embedded
 # IPython kernel via a per-PID proxy kernelspec. Based on ipyida's notebook.py.
 
+import atexit
 import json
 import logging
 import os
@@ -19,7 +20,7 @@ import binaryninja as bn
 import binaryninjaui as bnui
 import nbformat
 from jupyter_client import find_connection_file
-from jupyter_core.paths import jupyter_data_dir
+from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir
 
 from .install import binja_pythonpath_env, binja_site_packages_dir, pip_install_packages
 from .user_ns import _BinjaMagicVariablesProvider
@@ -216,6 +217,7 @@ class NotebookManager(object):
         self.nb_pipe_thread = None
         self.nb_pipe_buffer = []
         self.nb_pipe_lock = threading.Lock()
+        self._atexit_registered = False
 
     @staticmethod
     def ensure_kernel_proxy_installed():
@@ -266,6 +268,47 @@ class NotebookManager(object):
             if psutil.pid_exists(pid):
                 continue
             shutil.rmtree(os.path.join(kernels_dir, name), ignore_errors=True)
+
+    @staticmethod
+    def _cleanup_stale_jpserver_files():
+        """Remove jpserver-<pid>.json runtime files whose owning process is
+        dead. Binary Ninja crashing (or the job-object SIGKILL'ing the
+        notebook subprocess on host exit) leaves these behind, and
+        ``jupyter notebook list`` then keeps reporting dead servers
+        forever. The pid is in the filename, so check it with psutil.
+        """
+        try:
+            import psutil
+        except ImportError:
+            return
+        runtime_dir = jupyter_runtime_dir()
+        if not os.path.isdir(runtime_dir):
+            return
+        prefix = "jpserver-"
+        suffix = ".json"
+        for name in os.listdir(runtime_dir):
+            if not (name.startswith(prefix) and name.endswith(suffix)):
+                continue
+            try:
+                pid = int(name[len(prefix):-len(suffix)])
+            except ValueError:
+                continue
+            if psutil.pid_exists(pid):
+                continue
+            try:
+                os.remove(os.path.join(runtime_dir, name))
+            except OSError:
+                pass
+
+    @staticmethod
+    def _remove_jpserver_file(pid):
+        if not pid:
+            return
+        path = os.path.join(jupyter_runtime_dir(), "jpserver-%d.json" % pid)
+        try:
+            os.remove(path)
+        except OSError:
+            pass
 
     def ensure_kernelspec_installed(self):
         """Install (or refresh) this Binary Ninja instance's proxy kernelspec.
@@ -430,6 +473,8 @@ class NotebookManager(object):
                not self.ensure_kernelspec_installed():
                 raise Exception("Could not find or install all requirements")
 
+        self._cleanup_stale_jpserver_files()
+
         ipynb_path = self._resolve_notebook_location(args.get("filename"))
         anchor_dir = os.path.dirname(ipynb_path)
 
@@ -456,6 +501,7 @@ class NotebookManager(object):
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 text=True,
             )
+            self._ensure_atexit_registered()
             # Drain stdout immediately. Otherwise the OS pipe buffer (~4KB
             # on Windows) can fill during the startup-polling window and
             # block the server's own logger -- which then never finishes
@@ -560,8 +606,29 @@ class NotebookManager(object):
             return False
         return True
 
+    def _ensure_atexit_registered(self):
+        # Binary Ninja's normal Quit path goes through Python shutdown, so
+        # atexit handlers fire while our nb_proc is still alive -- we get
+        # one shot at /api/shutdown which lets the server delete its own
+        # jpserver-<pid>.json. Without this the job-object KILL_ON_JOB_CLOSE
+        # SIGKILLs the notebook subprocess and the runtime file leaks,
+        # leaving a dead entry in `jupyter notebook list` indefinitely.
+        # (Hard binja crash still leaks, but _cleanup_stale_jpserver_files
+        # sweeps those on the next %open_notebook.)
+        if self._atexit_registered:
+            return
+        atexit.register(self._atexit_shutdown)
+        self._atexit_registered = True
+
+    def _atexit_shutdown(self):
+        try:
+            self.shutdown()
+        except Exception:
+            pass
+
     def shutdown(self):
         if self.nb_proc:
+            nb_pid = self.nb_proc.pid
             graceful = False
             try:
                 graceful = self._shutdown_server_via_api(timeout=3)
@@ -577,6 +644,8 @@ class NotebookManager(object):
                     self.nb_proc.terminate()
                 except Exception:
                     pass
+                # Server didn't get a chance to delete its own runtime file.
+                self._remove_jpserver_file(nb_pid)
         if self.nb_pipe_thread:
             self.nb_pipe_thread.join(timeout=2)
         spec_dir = os.path.join(

--- a/notebook.py
+++ b/notebook.py
@@ -1,0 +1,585 @@
+# -*- encoding: utf8 -*-
+#
+# Launch a Jupyter Notebook from Binary Ninja and connect it to the embedded
+# IPython kernel via a per-PID proxy kernelspec. Based on ipyida's notebook.py.
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+import webbrowser
+
+import binaryninja as bn
+import binaryninjaui as bnui
+import nbformat
+from jupyter_client import find_connection_file
+from jupyter_core.paths import jupyter_data_dir
+
+from .install import binja_pythonpath_env, binja_site_packages_dir, pip_install_packages
+from .user_ns import _BinjaMagicVariablesProvider
+from .utils import detect_python_path
+
+
+def _notebook_major_version():
+    try:
+        import notebook
+    except ImportError:
+        return None
+    try:
+        return int(notebook.__version__.split('.')[0])
+    except (AttributeError, ValueError):
+        return None
+
+
+def _list_running_servers():
+    major = _notebook_major_version()
+    if major is not None and major >= 7:
+        from jupyter_server.serverapp import list_running_servers
+    else:
+        from notebook.notebookapp import list_running_servers
+    return list_running_servers()
+
+
+def _server_root_dir(server_info):
+    return server_info.get("root_dir") or server_info.get("notebook_dir") or ""
+
+
+def _python_executable():
+    path = detect_python_path()
+    if path is None:
+        raise RuntimeError(
+            "Could not locate a Python interpreter. Configure "
+            "python.binaryOverride in Binary Ninja settings."
+        )
+    return path
+
+
+def _proxy_runner_path():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "proxy_runner.py")
+
+
+def _current_binary_path():
+    """Return the path of the currently active BinaryView, or None."""
+    try:
+        bv = _BinjaMagicVariablesProvider().current_view
+    except Exception:
+        return None
+    if bv is None:
+        return None
+    fm = getattr(bv, "file", None)
+    if fm is None:
+        return None
+    name = getattr(fm, "filename", None)
+    if name:
+        return name
+    return getattr(fm, "original_filename", None)
+
+
+# --- Subprocess lifetime binding -------------------------------------------
+# Bind the notebook subprocess to Binary Ninja's process lifetime so the OS
+# kills it when Binary Ninja goes away (crash, force-kill, browser-driven
+# shutdown). Windows: Job Object. Linux: PR_SET_PDEATHSIG.
+
+if sys.platform == 'win32':
+    import ctypes
+    from ctypes import wintypes
+
+    _kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+    _JobObjectExtendedLimitInformation = 9
+
+    class _IO_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", wintypes.LARGE_INTEGER),
+            ("PerJobUserTimeLimit", wintypes.LARGE_INTEGER),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+            ("IoInfo", _IO_COUNTERS),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    _kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    _kernel32.CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
+    _kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    _kernel32.SetInformationJobObject.argtypes = [
+        wintypes.HANDLE, ctypes.c_int, wintypes.LPVOID, wintypes.DWORD,
+    ]
+    _kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    _kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+
+    _ipybinja_job_handle = None
+
+    def _get_ipybinja_job():
+        global _ipybinja_job_handle
+        if _ipybinja_job_handle is not None:
+            return _ipybinja_job_handle
+        job = _kernel32.CreateJobObjectW(None, None)
+        if not job:
+            return None
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not _kernel32.SetInformationJobObject(
+            job, _JobObjectExtendedLimitInformation,
+            ctypes.byref(info), ctypes.sizeof(info),
+        ):
+            _kernel32.CloseHandle(job)
+            return None
+        _ipybinja_job_handle = job
+        return job
+
+    def _bind_proc_to_host_lifetime(proc):
+        job = _get_ipybinja_job()
+        if job is None:
+            return
+        handle = getattr(proc, "_handle", None)
+        if handle is None:
+            return
+        if not _kernel32.AssignProcessToJobObject(job, int(handle)):
+            err = ctypes.get_last_error()
+            logging.warning(
+                "AssignProcessToJobObject failed (err=%d); notebook will not "
+                "be auto-killed on Binary Ninja crash", err
+            )
+
+else:
+    def _bind_proc_to_host_lifetime(proc):
+        pass
+
+
+def _child_set_pdeathsig():
+    if not sys.platform.startswith('linux'):
+        return
+    try:
+        import ctypes
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        PR_SET_PDEATHSIG = 1
+        SIGTERM = 15
+        libc.prctl(PR_SET_PDEATHSIG, SIGTERM, 0, 0, 0)
+    except Exception:
+        pass
+
+
+def _popen_python(*args, **kwargs):
+    python = _python_executable()
+    if sys.platform == 'win32':
+        si_hidden_window = subprocess.STARTUPINFO()
+        si_hidden_window.dwFlags = subprocess.STARTF_USESHOWWINDOW
+        si_hidden_window.wShowWindow = subprocess.SW_HIDE
+        kwargs["startupinfo"] = si_hidden_window
+    elif sys.platform.startswith('linux'):
+        kwargs.setdefault("preexec_fn", _child_set_pdeathsig)
+    kwargs.setdefault("env", binja_pythonpath_env())
+    proc = subprocess.Popen([python] + list(args), **kwargs)
+    _bind_proc_to_host_lifetime(proc)
+    return proc
+
+
+def _popen_python_module(module, *args, **kwargs):
+    return _popen_python("-m", module, *args, **kwargs)
+
+
+class NotebookManager(object):
+
+    def __init__(self, connection_file):
+        self.connection_file = connection_file
+        self.nb_proc = None
+        self.nb_pipe_thread = None
+        self.nb_pipe_buffer = []
+        self.nb_pipe_lock = threading.Lock()
+
+    @staticmethod
+    def ensure_kernel_proxy_installed():
+        try:
+            import jupyter_kernel_proxy  # noqa: F401
+            return True
+        except ImportError:
+            return pip_install_packages("jupyter-kernel-proxy")
+
+    @staticmethod
+    def ensure_notebook_installed():
+        try:
+            import notebook  # noqa: F401
+            return True
+        except ImportError:
+            return pip_install_packages("notebook")
+
+    @staticmethod
+    def ensure_psutil_installed():
+        try:
+            import psutil  # noqa: F401
+            return True
+        except ImportError:
+            return pip_install_packages("psutil")
+
+    def _kernelspec_name(self):
+        return "ipybinja-%d" % os.getpid()
+
+    @staticmethod
+    def _cleanup_stale_kernelspecs():
+        try:
+            import psutil
+        except ImportError:
+            return
+        kernels_dir = os.path.join(jupyter_data_dir(), "kernels")
+        if not os.path.isdir(kernels_dir):
+            return
+        prefix = "ipybinja-"
+        for name in os.listdir(kernels_dir):
+            if not name.startswith(prefix):
+                continue
+            try:
+                pid = int(name[len(prefix):])
+            except ValueError:
+                continue
+            if pid == os.getpid():
+                continue
+            if psutil.pid_exists(pid):
+                continue
+            shutil.rmtree(os.path.join(kernels_dir, name), ignore_errors=True)
+
+    def ensure_kernelspec_installed(self):
+        """Install (or refresh) this Binary Ninja instance's proxy kernelspec.
+
+        Writes ``<data_dir>/kernels/ipybinja-<pid>/kernel.json`` whose argv
+        runs our proxy_runner.py as a standalone script (passing the
+        plugin-local absolute path, since the ipybinja package isn't on the
+        external Python's sys.path) with the kernel-file basename as
+        positional argv[2].
+        """
+        try:
+            import jupyter_kernel_proxy  # noqa: F401
+        except ImportError:
+            return False
+
+        self._cleanup_stale_kernelspecs()
+
+        spec_dir = os.path.join(
+            jupyter_data_dir(), "kernels", self._kernelspec_name()
+        )
+        spec_path = os.path.join(spec_dir, "kernel.json")
+        spec = {
+            "argv": [
+                _python_executable(),
+                _proxy_runner_path(),
+                "{connection_file}",
+                os.path.basename(self.connection_file),
+            ],
+            "display_name": "Binary Ninja (PID %d)" % os.getpid(),
+            "language": "python",
+            "metadata": {"debugger": True},
+            # python.exe spawned standalone by jupyter doesn't inherit
+            # Binary Ninja's sys.path, and the bundled interpreter ships
+            # with a _pth file that disables PYTHONPATH. proxy_runner.py
+            # reads IPYBINJA_EXTRA_PATH and prepends it to sys.path before
+            # ``import jupyter_kernel_proxy``.
+            "env": {"IPYBINJA_EXTRA_PATH": binja_site_packages_dir()},
+        }
+        try:
+            os.makedirs(spec_dir, exist_ok=True)
+            with open(spec_path, "w") as f:
+                json.dump(spec, f)
+        except OSError as e:
+            print("-> Could not write ipybinja kernelspec: %s" % e)
+            return False
+        return True
+
+    @staticmethod
+    def _server_reachable(server_info, timeout=1.0):
+        """list_running_servers() yields whatever is in <jupyter_runtime_dir>
+        /jpserver-*.json without verifying the server is alive. A binja
+        session that crashed without removing its json leaves a stale entry
+        whose URL still parses but whose port is dead. Ping /api/status to
+        weed those out before we trust the entry.
+        """
+        base = server_info.get("url", "").rstrip("/")
+        if not base:
+            return False
+        token = server_info.get("token", "")
+        headers = {"Authorization": "token " + token} if token else {}
+        try:
+            req = urllib.request.Request(base + "/api/status", headers=headers)
+            urllib.request.urlopen(req, timeout=timeout).read()
+            return True
+        except (urllib.error.URLError, OSError):
+            return False
+
+    @staticmethod
+    def _path_norm(p):
+        """Normalize a path for cross-format comparison: slash style, case
+        (Windows), and . / .. components. Binja can hand us forward-slashed
+        paths while jupyter stores ``root_dir`` after ``os.path.abspath``
+        which uses native separators -- without normalization the
+        ``startswith`` check below silently never matches.
+        """
+        if not p:
+            return p
+        return os.path.normcase(os.path.normpath(p))
+
+    def _get_running_notebook_config(self, anchor_path):
+        anchor_norm = self._path_norm(anchor_path)
+        for server_info in _list_running_servers():
+            root = _server_root_dir(server_info)
+            if not root:
+                continue
+            if not anchor_norm.startswith(self._path_norm(root)):
+                continue
+            if not self._server_reachable(server_info):
+                continue
+            return server_info
+        return None
+
+    def _create_proxy_session(self, server_info, relative_path):
+        """Pre-create a kernel session bound to this Binary Ninja's proxy
+        kernel. Notebook 7's JupyterLab-based frontend ignores the legacy
+        ?kernel_name= query argument; posting the session beforehand makes
+        the page reuse the attached proxy kernel when it opens.
+        """
+        base = server_info.get("url", "").rstrip("/")
+        token = server_info.get("token", "")
+        if not base:
+            return
+        body = json.dumps({
+            "path": "/".join(relative_path.split(os.path.sep)),
+            "type": "notebook",
+            "name": "",
+            "kernel": {"name": self._kernelspec_name()},
+        }).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = "token " + token
+        req = urllib.request.Request(
+            base + "/api/sessions", data=body, headers=headers, method="POST",
+        )
+        try:
+            urllib.request.urlopen(req, timeout=10).read()
+        except (urllib.error.URLError, OSError) as e:
+            print("-> Could not pre-create proxy session: %s" % e)
+
+    def _parse_args(self, line):
+        args = line.split()
+        parsed = dict()
+        if "--skip-dependency-checks" in args:
+            parsed["skip_dependency_checks"] = True
+            args.remove("--skip-dependency-checks")
+        if len(args) > 0:
+            parsed["filename"] = args[0]
+        return parsed
+
+    def _resolve_notebook_location(self, filename_arg):
+        """Pick a directory + .ipynb filename based on current view, or fall
+        back to Binary Ninja's user directory.
+        """
+        binary_path = _current_binary_path()
+        if binary_path:
+            base_dir = os.path.dirname(binary_path)
+            default_stem = os.path.basename(binary_path).rsplit(".", 1)[0]
+        else:
+            base_dir = bn.user_directory() or os.getcwd()
+            default_stem = "binja_session"
+        stem = filename_arg if filename_arg else default_stem
+        if not stem.endswith(".ipynb"):
+            stem += ".ipynb"
+        return os.path.join(base_dir, stem)
+
+    def open_notebook(self, line):
+        """Open a Jupyter Notebook connected to Binary Ninja's IPython kernel.
+
+        Arguments:
+            --skip-dependency-checks    Skip checks for notebook /
+                                        jupyter-kernel-proxy / psutil
+            <filename>                  Notebook filename (.ipynb optional);
+                                        defaults to the current binary's name
+                                        in the same directory.
+        """
+        args = self._parse_args(line)
+
+        if not args.get("skip_dependency_checks", False):
+            if not self.ensure_notebook_installed() or \
+               not self.ensure_kernel_proxy_installed() or \
+               not self.ensure_psutil_installed() or \
+               not self.ensure_kernelspec_installed():
+                raise Exception("Could not find or install all requirements")
+
+        ipynb_path = self._resolve_notebook_location(args.get("filename"))
+        anchor_dir = os.path.dirname(ipynb_path)
+
+        nb_server_info = self._get_running_notebook_config(anchor_dir)
+
+        if nb_server_info is None:
+            print("-> Starting notebook")
+            # Binary Ninja's bundled python.exe has a _pth file that
+            # ignores PYTHONPATH, so ``python -m notebook`` can't see
+            # packages we installed under binja_site_packages_dir().
+            # Inline a bootstrap that injects sys.path then runs the
+            # ``notebook`` module via runpy.
+            binja_site = binja_site_packages_dir()
+            bootstrap = (
+                "import sys, runpy; "
+                f"sys.path.insert(0, {binja_site!r}); "
+                "sys.argv[:] = ['notebook'] + sys.argv[1:]; "
+                "runpy.run_module('notebook', run_name='__main__')"
+            )
+            self.nb_proc = _popen_python(
+                "-c", bootstrap,
+                "--no-browser", "-y",
+                "--notebook-dir", anchor_dir,
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                text=True,
+            )
+            # Drain stdout immediately. Otherwise the OS pipe buffer (~4KB
+            # on Windows) can fill during the startup-polling window and
+            # block the server's own logger -- which then never finishes
+            # binding the port.
+            self.nb_pipe_thread = threading.Thread(
+                target=self._notebook_stdout_thread, daemon=True
+            )
+            self.nb_pipe_thread.start()
+            try_count = 0
+            while nb_server_info is None and self.nb_proc.poll() is None and try_count < 20:
+                time.sleep(0.5)
+                nb_server_info = self._get_running_notebook_config(anchor_dir)
+                try_count += 1
+            if nb_server_info is None:
+                self.nb_proc.terminate()
+                with self.nb_pipe_lock:
+                    for s in self.nb_pipe_buffer:
+                        print(s, end="")
+                    self.nb_pipe_buffer = []
+                raise Exception("Couldn't start Jupyter Notebook")
+
+        if not os.path.exists(ipynb_path):
+            os.makedirs(os.path.dirname(ipynb_path), exist_ok=True)
+            with open(ipynb_path, "w") as f:
+                nb = nbformat.versions[nbformat.current_nbformat].new_notebook()
+                json.dump(nb, f)
+        relative_path = os.path.relpath(ipynb_path, _server_root_dir(nb_server_info))
+        # Touch the connection file so jupyter_kernel_proxy's atime-based
+        # fallback selection picks ours. Primary selection is via argv[2].
+        try:
+            os.utime(find_connection_file(self.connection_file), None)
+        except OSError:
+            pass
+        self._create_proxy_session(nb_server_info, relative_path)
+        url = nb_server_info.get("url") + \
+            "notebooks/" + "/".join(relative_path.split(os.path.sep)) + \
+            '?kernel_name=' + self._kernelspec_name() + \
+            '&token=' + nb_server_info.get("token")
+        # Sanity-check that the server is actually reachable -- list_running_servers
+        # reads jpserver-*.json files which can lag behind a server that crashed
+        # right after the banner.
+        base = nb_server_info.get("url", "").rstrip("/")
+        token = nb_server_info.get("token", "")
+        try:
+            api_req = urllib.request.Request(
+                base + "/api/status",
+                headers={"Authorization": "token " + token} if token else {},
+            )
+            urllib.request.urlopen(api_req, timeout=3).read()
+            reachable = True
+        except (urllib.error.URLError, OSError) as e:
+            reachable = False
+            print(f"-> Warning: notebook server at {base} not responding: {e}")
+            print(f"-> nb_proc.poll() = {self.nb_proc.poll() if self.nb_proc else 'no proc'}")
+        if reachable:
+            print(f"-> Opening {url}")
+        webbrowser.open(url)
+        return url
+
+    def _notebook_stdout_thread(self):
+        while self.nb_proc.poll() is None:
+            r = self.nb_proc.stdout.readline()
+            with self.nb_pipe_lock:
+                self.nb_pipe_buffer.append(r)
+
+    def notebook_log(self, line):
+        "Print output from Jupyter Notebook started by IPyBinja"
+        if self.nb_proc:
+            with self.nb_pipe_lock:
+                for s in self.nb_pipe_buffer:
+                    print(s, end="")
+                self.nb_pipe_buffer = []
+        else:
+            print("Notebook isn't running or managed by this IPyBinja instance")
+
+    def _shutdown_server_via_api(self, timeout=3):
+        if self.nb_proc is None:
+            return False
+        server_info = None
+        try:
+            for info in _list_running_servers():
+                if info.get("pid") == self.nb_proc.pid:
+                    server_info = info
+                    break
+        except Exception:
+            return False
+        if server_info is None:
+            return False
+        base = server_info.get("url", "").rstrip("/")
+        if not base:
+            return False
+        token = server_info.get("token", "")
+        headers = {}
+        if token:
+            headers["Authorization"] = "token " + token
+        req = urllib.request.Request(
+            base + "/api/shutdown", data=b"", headers=headers, method="POST",
+        )
+        try:
+            urllib.request.urlopen(req, timeout=timeout)
+        except (urllib.error.URLError, OSError):
+            return False
+        return True
+
+    def shutdown(self):
+        if self.nb_proc:
+            graceful = False
+            try:
+                graceful = self._shutdown_server_via_api(timeout=3)
+            except Exception:
+                graceful = False
+            if graceful:
+                try:
+                    self.nb_proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    graceful = False
+            if not graceful:
+                try:
+                    self.nb_proc.terminate()
+                except Exception:
+                    pass
+        if self.nb_pipe_thread:
+            self.nb_pipe_thread.join(timeout=2)
+        spec_dir = os.path.join(
+            jupyter_data_dir(), "kernels", self._kernelspec_name()
+        )
+        shutil.rmtree(spec_dir, ignore_errors=True)

--- a/proxy_runner.py
+++ b/proxy_runner.py
@@ -1,0 +1,123 @@
+# -*- encoding: utf8 -*-
+#
+# Wrapper around jupyter_kernel_proxy that patches three behaviours:
+#
+# (a) KernelProxyManager._send_proxy_kernel_info is a 3-second fallback:
+#     if the real kernel does not reply to kernel_info_request within
+#     that window the proxy synthesises a minimal reply that lacks the
+#     "debugger" field. On notebook 7 / JupyterLab the debug button is
+#     enabled based on kernel_info_reply.debugger -- the fallback racing
+#     the real reply silently disables it.
+#
+# (b) Clicking "Shutdown" / "Restart" in the JupyterLab kernel menu sends
+#     a shutdown_request on the control (and historically shell) channel.
+#     If we forward it, Binary Ninja's embedded ipykernel calls
+#     IOLoop.stop() on the kernel's loop, which -- because qasync ties
+#     asyncio to Binary Ninja's Qt event loop -- tears Binary Ninja down
+#     with it. Instead we answer locally with shutdown_reply and drop the
+#     message: the notebook server then terminates this proxy subprocess
+#     only, and Binary Ninja's kernel keeps running.
+#
+# (c) connect_to_last picks the newest kernel-*.json by st_atime, which
+#     is fragile after a few open/shutdown cycles. The ipybinja kernel-
+#     spec passes Binary Ninja's connection-file basename as argv[2];
+#     use it to dial the right kernel directly.
+#
+# Based on https://github.com/yufengzjj/ipyida proxy_runner.py.
+
+import os
+import sys
+
+# Binary Ninja's bundled python.exe ships with a python<ver>._pth file that
+# disables site detection and ignores PYTHONPATH. The site-packages where
+# we pip-installed jupyter_kernel_proxy isn't on sys.path until we put it
+# there manually. The plugin passes the directory list via this env var in
+# kernel.json. Must happen BEFORE the jupyter_kernel_proxy import.
+_extra = os.environ.get("IPYBINJA_EXTRA_PATH")
+if _extra:
+    for _p in _extra.split(os.pathsep):
+        if _p and _p not in sys.path:
+            sys.path.insert(0, _p)
+
+import jupyter_kernel_proxy
+from jupyter_kernel_proxy import KernelProxyManager, JupyterMessage
+
+
+# --- (a) keep the JupyterLab debug button enabled -------------------------
+
+_orig_send_proxy_kernel_info = KernelProxyManager._send_proxy_kernel_info
+
+
+def _patched_send_proxy_kernel_info(self, request):
+    if getattr(self.server, "proxy_target", None) is not None:
+        # Real kernel will answer; do not race it with a stripped-down
+        # fallback reply that drops the "debugger" flag.
+        return
+    return _orig_send_proxy_kernel_info(self, request)
+
+
+KernelProxyManager._send_proxy_kernel_info = _patched_send_proxy_kernel_info
+
+
+# --- (b) intercept browser-initiated shutdown so Binary Ninja survives ----
+
+def _make_shutdown_interceptor(channel_name):
+    def handler(server, target_stream, data):
+        msg = JupyterMessage.parse(data)
+        restart = (msg.content or {}).get("restart", False)
+        reply_stream = getattr(server.streams, channel_name)
+        reply_parts = msg.identities + server.make_multipart_message(
+            "shutdown_reply",
+            {"restart": restart, "status": "ok"},
+            parent_header=msg.header,
+        )
+        reply_stream.send_multipart(reply_parts)
+        reply_stream.flush()
+        # Return None to drop the request -- do NOT forward to Binary Ninja's kernel.
+        return None
+    return handler
+
+
+_orig_init = KernelProxyManager.__init__
+
+
+def _patched_init(self, server):
+    _orig_init(self, server)
+    self.server.intercept_message(
+        "control", "shutdown_request", _make_shutdown_interceptor("control"),
+    )
+    self.server.intercept_message(
+        "shell", "shutdown_request", _make_shutdown_interceptor("shell"),
+    )
+
+
+KernelProxyManager.__init__ = _patched_init
+
+
+# --- (c) connect deterministically to Binary Ninja's kernel ---------------
+
+_target_kernel_file = sys.argv[2] if len(sys.argv) > 2 else None
+
+if _target_kernel_file:
+    def _patched_connect_to_last(self):
+        self.update_running_kernels()
+        try:
+            self.connect_to(_target_kernel_file)
+            return
+        except ValueError:
+            pass
+        if self.kernels:
+            self.connect_to(next(iter(self.kernels.keys())))
+
+    KernelProxyManager.connect_to_last = _patched_connect_to_last
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python proxy_runner.py <connection_file> [<binja_kernel_file>]")
+        sys.exit(1)
+    jupyter_kernel_proxy.start(sys.argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ qtconsole >= 4.3
 qasync >= 0.23.0
 jupyter-client >= 6, != 7.0.*, != 7.1.*, != 7.2.*, != 7.3.*, != 7.4.0, != 7.4.1, != 7.4.2, != 7.4.3, != 7.4.4, != 7.4.5, != 7.4.6, != 7.4.7
 nbformat >= 5.7.0
+notebook
+jupyter-kernel-proxy
+psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ipykernel >= 5.1.4
 qtconsole >= 4.3
 qasync >= 0.23.0
-jupyter-client >= 6, != 7.0.*, != 7.1.*, != 7.2.*, != 7.3.*, != 7.4.0, != 7.4.1, != 7.4.2, != 7.4.3, != 7.4.4, != 7.4.5, != 7.4.6, != 7.4.7
+jupyter-client >= 6
 nbformat >= 5.7.0
 notebook
 jupyter-kernel-proxy

--- a/user_ns.py
+++ b/user_ns.py
@@ -1,182 +1,319 @@
-import logging
 import threading
 from typing import Optional, Union, Mapping
-from weakref import WeakValueDictionary
-
+import contextlib
 import binaryninja as bn
 import binaryninjaui as bnui
+from binaryninja.exceptions import ILException
+
+def _with_ref(v, parent):
+    # Keep a reference of parent c++ object in v
+    # This prevents parent from being destroyed
+    # while v is still alive
+    if v is not None:
+        v._self_ref = parent
+    return v
 
 
-ILBasicBlockTypes = Union[bn.LowLevelILBasicBlock, bn.MediumLevelILBasicBlock, bn.HighLevelILBasicBlock]
-ILInstructionTypes = Union[bn.LowLevelILInstruction, bn.MediumLevelILInstruction, bn.HighLevelILInstruction]
+class _BinjaMagicVariablesProvider:
+    MAGIC_VARIABLES = {
+        'current_thread',
+        'current_view',
+        'bv',
+        'current_function',
+        'current_basic_block',
+        'current_address',
+        'here',
+        'current_selection',
+        'current_raw_offset',
+        'current_llil',
+        'current_mlil',
+        'current_hlil',
+        'current_data_var',
+        'current_symbol',
+        'current_symbols',
+        'current_segment',
+        'current_sections',
+        'current_comment',
+        'current_il_index',
+        'current_il_function',
+        'current_il_instruction',
+        'current_il_basic_block',
+        'current_ui_context',
+        'current_ui_view_frame',
+        'current_ui_view',
+        'current_ui_action_handler',
+        'current_ui_view_location',
+        'current_ui_action_context',
+        'current_token',
+        'current_variable'
+    }
 
+    @property
+    def current_thread(self) -> threading.Thread:
+        return threading.current_thread()
 
-class BinjaMagicVarSnapshot:
+    @property
+    def current_view(self) -> Optional[bn.BinaryView]:
+        frame = self.current_ui_view_frame
+        if frame is None:
+            return None
+        return _with_ref(frame.getCurrentBinaryView(), frame)
 
-    current_ui_context: Optional[bnui.UIContext]
-    current_ui_view_frame: Optional[bnui.ViewFrame]
-    current_ui_view: Optional[bnui.View]
-    current_ui_action_handler: Optional[bnui.UIActionHandler]
-    current_ui_view_location: Optional[bnui.ViewLocation]
-    current_ui_action_context: Optional[bnui.UIActionContext]
-    current_token: Optional[bn.InstructionTextToken]
-    current_function: Optional[bn.Function]
-    current_variable: Optional[bn.Variable]
-    current_il_function: Optional[Union[bn.Function, bn.ILFunctionType]]
-    current_il_index: Optional[int]
-    current_il_basic_block: Optional[ILBasicBlockTypes]
-    current_il_instruction: Optional[ILInstructionTypes]
-    current_view: Optional[bn.BinaryView]
-    bv: Optional[bn.BinaryView]
-    current_address: int
-    here: int
-    current_comment: Optional[str]
-    current_sections: list[bn.Section]
-    current_segment: Optional[bn.Segment]
-    current_symbols: list[bn.CoreSymbol]
-    current_symbol: Optional[bn.CoreSymbol]
-    current_data_var: Optional[bn.DataVariable]
-    current_hlil: Optional[bn.HighLevelILFunction]
-    current_mlil: Optional[bn.MediumLevelILFunction]
-    current_llil: Optional[bn.LowLevelILFunction]
-    current_raw_offset: int
-    current_selection: Optional[tuple[int, int]]
-    current_basic_block: Optional[bn.BasicBlock]
-    current_thread: threading.Thread
+    @property
+    def bv(self) -> Optional[bn.BinaryView]:
+        return self.current_view
 
-    def __init__(self, ctx: Optional[bnui.UIContext]):
-        self.current_ui_context = ctx
-        self.current_ui_view_frame = ctx.getCurrentViewFrame() if ctx else None
-        self.current_ui_view = ctx.getCurrentView() if ctx else None
-        self.current_ui_action_handler = ctx.getCurrentActionHandler() if ctx else None
-        view_frame = self.current_ui_view_frame
-        view = self.current_ui_view
-        self.current_ui_view_location = view_frame.getViewLocation() if view_frame else None
-        self.current_ui_action_context = view.actionContext() if view else None
-        action_ctx = self.current_ui_action_context
-        token_state = action_ctx.token if action_ctx else None
-        self.current_token = token_state.token if token_state and token_state.valid else None
+    @property
+    def current_function(self) -> Optional[bn.Function]:
         view_location = self.current_ui_view_location
-        self.current_function = view_location.getFunction() if view_location else None
-        func = self.current_function
-        self.current_variable = bn.Variable.from_core_variable(func, token_state.localVar) \
-            if func and token_state and token_state.localVarValid else None
-        self.current_il_function = self._get_il_function(func, view_location)
-        il_func = self.current_il_function
-        self.current_il_index = view_location.getInstrIndex() if view_location else None
-        il_index = self.current_il_index
-        self.current_il_basic_block = il_func.get_basic_block_at(il_index) if il_func and il_index else None
-        self.current_il_instruction = il_func[il_index] \
-            if il_func and il_index and il_index < len(il_func) is not None else None
-        self.current_view = view_frame.getCurrentBinaryView() if view_frame else None
-        bv = self.current_view
-        self.bv = bv
-        self.current_address = view_location.getOffset() if view_location else 0
-        self.here = self.current_address
-        address = self.current_address if view_location and view_location.isValid() else None
-        self.current_comment = bv.get_comment_at(address) if bv and address is not None else None
-        self.current_sections = bv.get_sections_at(address) if bv and address is not None else []
-        self.current_segment = bv.get_segment_at(address) if bv and address is not None else None
-        self.current_symbols = bv.get_symbols(address, 1) if bv and address is not None else []
-        self.current_symbol = bv.get_symbol_at(address) if bv and address is not None else None
-        self.current_data_var = bv.get_data_var_at(address) if bv and address is not None else None
-        self.current_hlil = func.hlil if func else None
-        self.current_mlil = func.mlil if func else None
-        self.current_llil = func.llil if func else None
-        self.current_raw_offset = bv.get_data_offset_for_address(address) if bv and address is not None else 0
-        self.current_selection = view_frame.getSelectionOffsets() if view_frame else None
-        self.current_basic_block = func.get_basic_block_at(address) if func and address is not None else None
-        self.current_thread = threading.current_thread()
+        if view_location is None or not view_location.isValid():
+            return None
+        return view_location.getFunction()
 
-    @classmethod
-    def _get_il_function(cls, function: Optional[bn.Function], view_location: Optional[bnui.ViewLocation]) \
-            -> Optional[Union[bn.Function, bn.ILFunctionType]]:
-        from binaryninja import FunctionGraphType as GraphType
+    @property
+    def current_basic_block(self) -> Optional[bn.BasicBlock]:
+        function = self.current_function
+        location = self.current_address
+        if function is None:
+            return None
+        return function.get_basic_block_at(location)
+
+    @property
+    def current_address(self) -> int:
+        vl = self.current_ui_view_location
+        if vl is None:
+            return 0
+        return vl.getOffset()
+
+    @property
+    def here(self) -> int:
+        return self.current_address
+
+    @property
+    def current_selection(self) -> Optional[tuple[int, int]]:
+        frame = self.current_ui_view_frame
+        if frame is None:
+            return None
+        selection = frame.getSelectionOffsets()
+        return selection
+
+    @property
+    def current_raw_offset(self) -> int:
+        bv = self.bv
+        if not bv:
+            return 0
+        return bv.get_data_offset_for_address(self.current_address)
+
+    @property
+    def current_llil(self) -> Optional[bn.LowLevelILFunction]:
+        function = self.current_function
+        if function is None:
+            return None
+        with contextlib.suppress(ILException):
+            return function.llil
+
+    @property
+    def current_mlil(self) -> Optional[bn.MediumLevelILFunction]:
+        function = self.current_function
+        if function is None:
+            return None
+        with contextlib.suppress(ILException):
+            return function.mlil
+
+    @property
+    def current_hlil(self) -> Optional[bn.HighLevelILFunction]:
+        function = self.current_function
+        if function is None:
+            return None
+        with contextlib.suppress(ILException):
+            return function.hlil
+
+    @property
+    def current_data_var(self) -> Optional[bn.DataVariable]:
+        bv = self.bv
+        if bv is None:
+            return None
+        return bv.get_data_var_at(self.current_address)
+
+    @property
+    def current_symbol(self) -> Optional[bn.CoreSymbol]:
+        bv = self.bv
+        if bv is None:
+            return None
+        return bv.get_symbol_at(self.current_address)
+
+    @property
+    def current_symbols(self) -> list[bn.CoreSymbol]:
+        bv = self.bv
+        if bv is None:
+            return []
+        return bv.get_symbols(self.current_address, 1)
+
+    @property
+    def current_segment(self) -> Optional[bn.Segment]:
+        bv = self.bv
+        if bv is None:
+            return None
+        return bv.get_segment_at(self.current_address)
+
+    @property
+    def current_sections(self) -> list[bn.Section]:
+        bv = self.bv
+        if bv is None:
+            return []
+        return bv.get_sections_at(self.current_address)
+
+    @property
+    def current_comment(self) -> Optional[str]:
+        bv = self.bv
+        if bv is None:
+            return None
+        return bv.get_comment_at(self.current_address)
+
+    @property
+    def current_il_index(self) -> Optional[int]:
+        view_location = self.current_ui_view_location
+        if view_location is None or not view_location.isValid():
+            return None
+        return view_location.getInstrIndex()
+
+    @property
+    def current_il_function(self) -> Optional[Union[bn.Function, bn.ILFunctionType]]:
+        function = self.current_function
+        view_location = self.current_ui_view_location
         if function is None or view_location is None or not view_location.isValid():
             return None
-        il_type = view_location.getILViewType()
-        if il_type == GraphType.NormalFunctionGraph:
+        il_type = view_location.getILViewType().view_type
+        cls = bn.FunctionGraphType
+        if il_type == cls.NormalFunctionGraph:
             return None
-        elif il_type == GraphType.LowLevelILFunctionGraph:
+        elif il_type == cls.LowLevelILFunctionGraph:
             return function.llil
-        elif il_type == GraphType.LiftedILFunctionGraph:
+        elif il_type == cls.LiftedILFunctionGraph:
             return function.lifted_il
-        elif il_type == GraphType.LowLevelILSSAFormFunctionGraph:
-            return function.llil.ssa_form if function.llil is not None else None
-        elif il_type == GraphType.MediumLevelILFunctionGraph:
+        elif il_type == cls.LowLevelILSSAFormFunctionGraph:
+            return function.llil.ssa_form
+        elif il_type == cls.MediumLevelILFunctionGraph:
             return function.mlil
-        elif il_type == GraphType.MediumLevelILSSAFormFunctionGraph:
-            return function.mlil.ssa_form if function.mlil is not None else None
-        elif il_type == GraphType.MappedMediumLevelILFunctionGraph:
+        elif il_type == cls.MediumLevelILSSAFormFunctionGraph:
+            return function.mlil.ssa_form
+        elif il_type == cls.MappedMediumLevelILFunctionGraph:
             return function.mapped_medium_level_il
-        elif il_type == GraphType.MappedMediumLevelILSSAFormFunctionGraph:
-            return function.mapped_medium_level_il.ssa_form if function.mapped_medium_level_il is not None else None
-        elif il_type == GraphType.HighLevelILFunctionGraph:
+        elif il_type == cls.MappedMediumLevelILSSAFormFunctionGraph:
+            return function.mapped_medium_level_il.ssa_form
+        elif il_type == cls.HighLevelILFunctionGraph:
             return function.hlil
-        elif il_type == GraphType.HighLevelILSSAFormFunctionGraph:
-            return function.hlil.ssa_form if function.hlil is not None else None
-        elif il_type == GraphType.HighLevelLanguageRepresentationFunctionGraph:
+        elif il_type == cls.HighLevelILSSAFormFunctionGraph:
+            return function.hlil.ssa_form
+        elif il_type == cls.HighLevelLanguageRepresentationFunctionGraph:
             return None
         raise Exception(f'unexpected il type {il_type}')
 
+    @property
+    def current_il_instruction(self) -> Optional:
+        function = self.current_il_function
+        instr_index = self.current_il_index
+        if function is None or instr_index is None:
+            return None
+        if instr_index > len(function):
+            return None
+        return function[instr_index]
 
-class _MagicVariableSnapshot(BinjaMagicVarSnapshot):
+    @property
+    def current_il_basic_block(self) -> Optional:
+        function = self.current_il_function
+        instr_index = self.current_il_index
+        if function is None or instr_index is None:
+            return None
+        return function.get_basic_block_at(instr_index)
 
-    def __init__(self, ctx: Optional[bnui.UIContext]):
-        super().__init__(ctx)
-        self.ipy_set_magic_context = None
-        self.ipy_current_magic_context = None
-        self.ipy_all_magic_contexts = None
+    @property
+    def current_ui_context(self) -> Optional[bnui.UIContext]:
+        ctx = bnui.UIContext.activeContext()
+        if ctx is None:
+            if len(bnui.UIContext.allContexts())>0:
+                ctx = bnui.UIContext.allContexts()[0]
+        return ctx
+
+    @property
+    def current_ui_view_frame(self) -> Optional[bnui.ViewFrame]:
+        ctx = self.current_ui_context
+        if ctx is None:
+            return None
+        return _with_ref(ctx.getCurrentViewFrame(), ctx)
+
+    @property
+    def current_ui_view(self) -> Optional[bnui.View]:
+        ctx = self.current_ui_context
+        if ctx is None:
+            return None
+        return _with_ref(ctx.getCurrentView(), ctx)
+
+    @property
+    def current_ui_action_handler(self) -> Optional[bnui.UIActionHandler]:
+        ctx = self.current_ui_context
+        if ctx is None:
+            return None
+        return _with_ref(ctx.getCurrentActionHandler(), ctx)
+
+    @property
+    def current_ui_view_location(self) -> Optional[bnui.ViewLocation]:
+        view_frame = self.current_ui_view_frame
+        if view_frame is None:
+            return None
+        return _with_ref(view_frame.getViewLocation(), view_frame)
+
+    @property
+    def current_ui_action_context(self):
+        view = self.current_ui_view
+        if view is not None:
+            return _with_ref(view.actionContext(), view)
+        ctx = self.current_ui_context
+        if ctx is None:
+            return None
+        return _with_ref(ctx.getCurrentActionHandler(), ctx)
+
+    @property
+    def current_token(self) -> Optional[bn.InstructionTextToken]:
+        action_ctx = self.current_ui_action_context
+        if action_ctx is None or not hasattr(action_ctx, 'token'):
+            return None
+        token_state = action_ctx.token
+        if not token_state.valid:
+            return None
+        return token_state.token
+
+    @property
+    def current_variable(self) -> Optional[bn.Variable]:
+        action_ctx = self.current_ui_action_context
+        if action_ctx is None or not hasattr(action_ctx, 'token'):
+            return None
+        token_state = action_ctx.token
+        if not token_state.localVarValid:
+            return None
+        func = self.current_function
+        if func is None:
+            return None
+        return bn.Variable.from_core_variable(func, token_state.localVar)
+    
+    def take_snapshot(self) -> dict:
+        return {k: getattr(self, k) for k in self.MAGIC_VARIABLES}
 
 
 class UserNamespaceProvider(dict):
-
-    _MAGIC_VARS = set(vars(_MagicVariableSnapshot(None)).keys())
-
     def __init__(self, mapping=(), **kwargs):
         super().__init__(mapping, **kwargs)
+        self._magic_var_provider = _BinjaMagicVariablesProvider()
         # Reserve keys for magic variables
-        for var in self._MAGIC_VARS:
+        for var in _BinjaMagicVariablesProvider.MAGIC_VARIABLES:
             super().__setitem__(var, None)
-        self._session_context_overrides = WeakValueDictionary()
-        self._magic_vars = _MagicVariableSnapshot(None)
+        self.update_magic_snapshot()
             
-    def update_magic_snapshot(self, remote_client_id: Optional[str]) -> None:
-        if remote_client_id:
-            context = self._session_context_overrides.get(remote_client_id, None)
-            if context is None:
-                available_contexts = self._all_bnui_contexts
-                if len(available_contexts) == 1:
-                    context = available_contexts[0]
-                    self._session_context_overrides[remote_client_id] = context
-                    logging.info(f'automatically selecting ui context {context} for current IPython remote client')
-                else:
-                    logging.warning(f'no UI context is set for current IPython remote client, '
-                                    f'use ipynb_set_magic_context to select a UI context.\n'
-                                    f'Available contexts: {available_contexts}')
-        else:
-            context = bnui.UIContext.activeContext()
-
-        self._magic_vars = _MagicVariableSnapshot(context)
-        if remote_client_id is None:
-            return
-
-        self._magic_vars.ipy_set_magic_context = \
-            lambda ctx: self._set_session_override(remote_client_id, ctx)
-        self._magic_vars.ipy_current_magic_context = context
-        self._magic_vars.ipy_all_magic_contexts = self._all_bnui_contexts
-
-    def _set_session_override(self, session: Optional[str], context: Optional[bnui.UIContext]):
-        if session is None:
-            raise Exception('ipynb_set_magic_context can only be used outside embedded IPython Console')
-        self._session_context_overrides[session] = context
-
-    @property
-    def _all_bnui_contexts(self) -> list[bnui.UIContext]:
-        return [context for context in bnui.UIContext.allContexts()]
+    def update_magic_snapshot(self) -> None:
+        self._magic_vars = self._magic_var_provider.take_snapshot()
 
     def __getitem__(self, k):
-        if k in self._MAGIC_VARS:
+        if k in _BinjaMagicVariablesProvider.MAGIC_VARIABLES:
             return self._get_magic_var(k)
         return super().__getitem__(k)
 
@@ -189,7 +326,7 @@ class UserNamespaceProvider(dict):
         return super().__delitem__(k)
 
     def get(self, k, default=None):
-        if k in self._MAGIC_VARS:
+        if k in _BinjaMagicVariablesProvider.MAGIC_VARIABLES:
             return self._get_magic_var(k)
         return super().get(k, default)
 
@@ -202,16 +339,16 @@ class UserNamespaceProvider(dict):
         return super().pop(k, v)
 
     def _get_magic_var(self, k):
-        return getattr(self._magic_vars, k)
+        return self._magic_vars[k]
 
     @classmethod
     def _check_mutate(cls, k):
-        if k in cls._MAGIC_VARS:
+        if k in _BinjaMagicVariablesProvider.MAGIC_VARIABLES:
             raise Exception(f'cannot mutate magic variable {k}')
 
     @classmethod
     def _check_update(cls, k, v):
-        if k in cls._MAGIC_VARS and v is not None:
+        if k in _BinjaMagicVariablesProvider.MAGIC_VARIABLES and v is not None:
             raise Exception(f'cannot update magic variable {k} to {v}')
 
     def update(self, m: Mapping, **kwargs) -> None:


### PR DESCRIPTION
## Summary
  - Rewrite `user_ns.py`: magic variables (`current_view`, `current_function`, `here`, …) become live `@property`
  lookups instead of a one-shot constructor snapshot, so they always reflect current UI state. Keep parent C++ refs to
  avoid use-after-free, guard IL access against `ILException`, and drop the unused remote-client / per-session
  UI-context override plumbing.
  - New `%open_notebook` magic launches Jupyter Notebook and attaches it to Binja's embedded IPython kernel via a
  per-PID proxy kernelspec.
  - New `IPyBinja\Install Plugin Requirements` command pip-installs deps where Binja's bundled `python.exe` actually
  reads from (its `_pth` blocks PYTHONPATH/site).
  - Stability: graceful notebook-subprocess shutdown on Binja exit, stale `jpserver-*.json` / kernelspec sweep on next
  launch, in-process debugpy adapter so the Debug button doesn't time out, and a no-op `jupyter.widget.control` comm
  target to silence ipywidgets-missing log noise.